### PR TITLE
fix: nightly + conformance CI stability

### DIFF
--- a/.github/workflows/ci-conformance.yml
+++ b/.github/workflows/ci-conformance.yml
@@ -101,7 +101,7 @@ jobs:
           - name: macOS
             runner: macos-latest
             build-target: StandaloneOSX
-            hub-version: '3.19.5'
+            hub-version: ''
           - name: Windows
             runner: windows-2022
             build-target: StandaloneWindows64

--- a/.github/workflows/ci-conformance.yml
+++ b/.github/workflows/ci-conformance.yml
@@ -101,7 +101,7 @@ jobs:
           - name: macOS
             runner: macos-latest
             build-target: StandaloneOSX
-            hub-version: ''
+            hub-version: '3.19.5'
           - name: Windows
             runner: windows-2022
             build-target: StandaloneWindows64
@@ -143,7 +143,7 @@ jobs:
 
       - uses: buildalon/unity-setup@30fcbcb56c10ea5d64298e970d952b8d29bc268b  # v2
         id: unity-setup
-        timeout-minutes: 15
+        timeout-minutes: 30
         with:
           unity-version: 6000.0.65f1
           build-targets: ${{ matrix.build-target }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,6 +16,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0  # needed for git ls-tree on historical tags in test_client_skills
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
@@ -69,10 +71,11 @@ jobs:
 
       - uses: buildalon/unity-setup@30fcbcb56c10ea5d64298e970d952b8d29bc268b  # v2
         id: unity-setup
-        timeout-minutes: 15
+        timeout-minutes: 30
         with:
           unity-version: 6000.0.65f1
           build-targets: StandaloneLinux64
+          hub-version: '3.19.5'
 
       - uses: buildalon/activate-unity-license@e0d245d0787b7b9931b56ccbde3b508f6b70f1af  # v2
         with:


### PR DESCRIPTION
## Summary
- **nightly.yml**: Pin `hub-version: '3.19.5'` (Hub 3.20.1 installs to wrong path), `fetch-depth: 0` (shallow checkout breaks `git ls-tree` on historical tags), timeout 15→30min
- **ci-conformance.yml**: Pin macOS `hub-version: '3.19.5'` (was `''`), timeout 15→30min

## Test plan
- [ ] Nightly C# Full: hub-version pin prevents ENOENT
- [ ] Nightly Python Full: fetch-depth 0 fixes `test_installer_accepts_all_supported_release_skill_hashes`
- [ ] Conformance macOS: hub-version pin prevents path mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)