### PR TITLE
ci: add SonarCloud analysis + harden Codecov uploads

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -91,6 +91,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
+        continue-on-error: true
         uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac  # v5
         with:
           files: server/coverage.xml
@@ -135,10 +136,12 @@ jobs:
 
       - name: Upload test analytics to Codecov
         if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' && !cancelled()
+        continue-on-error: true
         uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac  # v5
         with:
           files: server/reports/server-junit.xml,server/reports/install-junit.xml,server/reports/scripts-junit.xml
           flags: python
+          fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
 

--- a/.github/workflows/ci-sonar.yml
+++ b/.github/workflows/ci-sonar.yml
@@ -1,0 +1,43 @@
+name: SonarCloud
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "server/src/**"
+      - "unity-plugin/**"
+      - "sonar-project.properties"
+  pull_request:
+    branches: [master]
+    paths:
+      - "server/src/**"
+      - "unity-plugin/**"
+      - "sonar-project.properties"
+  workflow_dispatch:
+
+permissions:
+  pull-requests: read
+
+jobs:
+  sonarcloud:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for blame
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install and run tests with coverage
+        working-directory: server
+        run: |
+          pip install ".[dev]"
+          PYTHONWARNDEFAULTENCODING=1 python -m pytest tests -m "not live and not monkey" -q --cov=unity_mcp --cov-report=xml:coverage.xml
+        continue-on-error: true
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@v3
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,12 @@
+sonar.projectKey=german-krasnikov_unity-biome-mcp
+sonar.organization=german-krasnikov
+
+sonar.sources=server/src/unity_mcp,unity-plugin/Editor,unity-plugin-reload/Editor
+sonar.tests=server/tests,unity-plugin/Editor/Tests
+sonar.python.version=3.10,3.11,3.12
+sonar.python.coverage.reportPaths=server/coverage.xml
+
+sonar.exclusions=**/*.meta,unity-test-project/**,**/__pycache__/**,**/node_modules/**
+sonar.test.exclusions=server/tests/**,unity-plugin/Editor/Tests/**,scripts/tests/**
+
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary

- Add SonarCloud CI analysis for Python + C# code
- Harden Codecov upload steps with continue-on-error

## Changes

- `sonar-project.properties`: project config (Python sources + C# sources, coverage path)
- `.github/workflows/ci-sonar.yml`: SonarCloud scan on push/PR to master
- `.github/workflows/ci-python.yml`: `continue-on-error: true` on both Codecov upload steps

## Test plan

- [x] Config-only changes, no Python/C# code modified
- [x] Lint clean
- [x] SONAR_TOKEN secret exists in repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)