### PR TITLE
fix: 3 SonarCloud bugs + enable C# analysis via dotnet-sonarscanner

### DIFF
--- a/.github/badges/tests.json
+++ b/.github/badges/tests.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "tests",
-  "message": "14,280 inventory",
+  "message": "14,287 inventory",
   "color": "59a7ff"
 }

--- a/.github/workflows/ci-sonar.yml
+++ b/.github/workflows/ci-sonar.yml
@@ -19,22 +19,23 @@ permissions:
   pull-requests: read
 
 jobs:
-  sonarcloud:
+  python-coverage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
-      - name: Install and run tests with coverage
+      - name: Install dependencies
+        run: pip install "./server[dev]"
+
+      - name: Run tests with coverage
         working-directory: server
         run: |
-          pip install ".[dev]"
-          PYTHONWARNDEFAULTENCODING=1 python -m pytest tests -m "not live and not monkey" -q --cov=unity_mcp --cov-report=xml:coverage.xml --cov-config=pyproject.toml
+          PYTHONWARNDEFAULTENCODING=1 python -m pytest tests -m "not live and not monkey" -q \
+            --cov=unity_mcp --cov-report=xml:coverage.xml --cov-config=pyproject.toml
         continue-on-error: true
 
       - name: Fix coverage paths for SonarCloud
@@ -42,11 +43,98 @@ jobs:
           if [ -f server/coverage.xml ]; then
             sed -i 's|<source>.*</source>|<source>.</source>|g' server/coverage.xml
             sed -i 's|filename="src/|filename="server/src/|g' server/coverage.xml
-            echo "Patched coverage.xml for SonarCloud"
           fi
 
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v3
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: coverage-xml
+          path: server/coverage.xml
+          retention-days: 1
+
+  sonar-unified:
+    runs-on: ubuntu-latest
+    needs: python-coverage
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Download coverage artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: coverage-xml
+          path: server
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set UPM cache path
+        id: upm-path
+        run: echo "path=$HOME/.cache/Unity/upm" >> "$GITHUB_OUTPUT"
+
+      - name: Cache UPM packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ${{ steps.upm-path.outputs.path }}
+          key: upm-Linux-${{ hashFiles('unity-test-project/Packages/packages-lock.json') }}
+          restore-keys: upm-Linux-
+
+      - uses: buildalon/unity-setup@30fcbcb56c10ea5d64298e970d952b8d29bc268b  # v2
+        id: unity-setup
+        timeout-minutes: 15
+        with:
+          unity-version: 6000.0.65f1
+          build-targets: StandaloneLinux64
+          cache-installation: true
+          hub-version: '3.19.5'
+
+      - uses: buildalon/activate-unity-license@e0d245d0787b7b9931b56ccbde3b508f6b70f1af  # v2
+        with:
+          license: 'Personal'
+          username: ${{ secrets.UNITY_EMAIL }}
+          password: ${{ secrets.UNITY_PASSWORD }}
+
+      - name: Generate .sln and .csproj
+        uses: buildalon/unity-action@2d420bea0f47fbe01377601fa3231bcf4de04f3a  # v3
+        with:
+          build-target: StandaloneLinux64
+          editor-path: ${{ steps.unity-setup.outputs.unity-editor-path }}
+          project-path: unity-test-project
+          args: -batchmode -nographics -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -quit
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68  # v6.0.0
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Install dotnet-sonarscanner
+        run: dotnet tool install --global dotnet-sonarscanner
+
+      - name: SonarScanner begin
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          dotnet sonarscanner begin \
+            /k:"german-krasnikov_unity-biome-mcp" \
+            /o:"german-krasnikov" \
+            /d:sonar.token="${SONAR_TOKEN}" \
+            /d:sonar.host.url="https://sonarcloud.io"
+
+      - name: Build C# solution
+        run: |
+          SLN=$(find unity-test-project -maxdepth 1 -name "*.sln" | head -1)
+          if [ -n "$SLN" ]; then
+            dotnet build "$SLN"
+          else
+            echo "::warning::No .sln found; C# analysis will be limited"
+          fi
+        continue-on-error: true
+
+      - name: SonarScanner end
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: dotnet sonarscanner end /d:sonar.token="${SONAR_TOKEN}"

--- a/.github/workflows/ci-sonar.yml
+++ b/.github/workflows/ci-sonar.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Install dotnet-sonarscanner
         run: dotnet tool install --global dotnet-sonarscanner
 
+      - name: Hide sonar-project.properties from dotnet scanner
+        run: mv sonar-project.properties sonar-project.properties.bak
+
       - name: SonarScanner begin
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -121,7 +124,15 @@ jobs:
             /k:"german-krasnikov_unity-biome-mcp" \
             /o:"german-krasnikov" \
             /d:sonar.token="${SONAR_TOKEN}" \
-            /d:sonar.host.url="https://sonarcloud.io"
+            /d:sonar.host.url="https://sonarcloud.io" \
+            /d:sonar.python.version="3.10,3.11,3.12" \
+            /d:sonar.python.coverage.reportPaths="server/coverage.xml" \
+            /d:sonar.sources="server/src/unity_mcp,unity-plugin/Editor,unity-plugin-reload/Editor" \
+            /d:sonar.tests="server/tests,unity-plugin/Editor/Tests" \
+            /d:sonar.exclusions="**/*.meta,unity-test-project/**,**/__pycache__/**" \
+            /d:sonar.test.exclusions="server/tests/**,unity-plugin/Editor/Tests/**,scripts/tests/**" \
+            /d:sonar.sourceEncoding="UTF-8" \
+            /d:sonar.cs.file.suffixes=".cs"
 
       - name: Build C# solution
         run: |
@@ -138,3 +149,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: dotnet sonarscanner end /d:sonar.token="${SONAR_TOKEN}"
+
+      - name: Restore sonar-project.properties
+        if: always()
+        run: mv sonar-project.properties.bak sonar-project.properties 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Codex synchronization.
 The values below are generated from registrations, pytest collection, Unity test discovery or source scanning, and package metadata. They are discovery counts, not a claim that every test was executed in the current checkout.
 
 <!-- README_STATS_START -->
-<img src="docs/assets/stats.svg" width="100%" alt="160 registered MCP tools. Test inventory: 14280 entries: 5758 regular Python, 511 Python stress, 634 live Python, and 7377 Unity source attributes. Unity count source: static source scan. Server package version: v1.41.0.">
+<img src="docs/assets/stats.svg" width="100%" alt="160 registered MCP tools. Test inventory: 14287 entries: 5765 regular Python, 511 Python stress, 634 live Python, and 7377 Unity source attributes. Unity count source: static source scan. Server package version: v1.41.0.">
 <!-- README_STATS_END -->
 
 ## Unity MCP Product Comparison

--- a/docs/assets/_meta.json
+++ b/docs/assets/_meta.json
@@ -1,7 +1,7 @@
 {
   "tools": 160,
-  "tests_total": 14280,
-  "tests_python": 5758,
+  "tests_total": 14287,
+  "tests_python": 5765,
   "tests_stress": 511,
   "tests_unity": 7377,
   "tests_unity_source": "static_grep",

--- a/docs/assets/stats.svg
+++ b/docs/assets/stats.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560 380" width="560" height="380"
      role="img" aria-labelledby="stats-title stats-desc">
   <title id="stats-title">Unity Biome MCP project inventory</title>
-  <desc id="stats-desc" data-biome-marker="STATS_DESC"><!-- BIOME:STATS_DESC -->160 registered MCP tools. Test inventory: 14280 entries: 5758 regular Python, 511 Python stress, 634 live Python, and 7377 Unity source attributes. Unity count source: static source scan. Server package version: v1.41.0.<!-- /BIOME:STATS_DESC --></desc>
+  <desc id="stats-desc" data-biome-marker="STATS_DESC"><!-- BIOME:STATS_DESC -->160 registered MCP tools. Test inventory: 14287 entries: 5765 regular Python, 511 Python stress, 634 live Python, and 7377 Unity source attributes. Unity count source: static source scan. Server package version: v1.41.0.<!-- /BIOME:STATS_DESC --></desc>
 
   <defs>
     <filter id="stats-core-glow" x="-80%" y="-80%" width="260%" height="260%">
@@ -238,12 +238,12 @@
   <g font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
     <text x="280" y="218" text-anchor="middle" fill="#f2f2f2" font-size="38"
           data-biome-marker="TESTS"
-          font-weight="700" data-mobile-critical="true"><!-- BIOME:TESTS -->14280<!-- /BIOME:TESTS --></text>
+          font-weight="700" data-mobile-critical="true"><!-- BIOME:TESTS -->14287<!-- /BIOME:TESTS --></text>
     <text x="280" y="245" text-anchor="middle" fill="#59a7ff" font-size="17"
           font-weight="700" data-mobile-critical="true">TEST INVENTORY</text>
     <text x="280" y="266" text-anchor="middle" fill="#d2d2d2" font-size="17"
           data-biome-marker="BREAKDOWN_PRIMARY"
-          data-mobile-critical="true"><!-- BIOME:BREAKDOWN_PRIMARY -->5758 regular / 511 stress<!-- /BIOME:BREAKDOWN_PRIMARY --></text>
+          data-mobile-critical="true"><!-- BIOME:BREAKDOWN_PRIMARY -->5765 regular / 511 stress<!-- /BIOME:BREAKDOWN_PRIMARY --></text>
     <text x="280" y="283" text-anchor="middle" fill="#b7b7bd" font-size="17"
           data-biome-marker="BREAKDOWN_SECONDARY"
           data-mobile-critical="true"><!-- BIOME:BREAKDOWN_SECONDARY -->634 live / 7377 Unity<!-- /BIOME:BREAKDOWN_SECONDARY --></text>
@@ -265,7 +265,7 @@
     <rect data-biome-bar="PY"
           x="82" y="337" height="7" width="309" rx="3" fill="#46e6a6" opacity=".85"/>
     <text data-biome-bar-label="PY"
-          x="478" y="346" text-anchor="end" fill="#b7b7bd" font-size="10">5758 py</text>
+          x="478" y="346" text-anchor="end" fill="#b7b7bd" font-size="10">5765 py</text>
 
     <rect data-biome-bar="STRESS"
           x="82" y="352" height="7" width="27" rx="3" fill="#f0a536" opacity=".85"/>

--- a/server/src/unity_mcp/bridge.py
+++ b/server/src/unity_mcp/bridge.py
@@ -326,7 +326,7 @@ class UnityBridge(HeartbeatMixin):
                     await self._send_queue.get()
                 )
             except asyncio.CancelledError:
-                break
+                raise
             try:
                 result = await self._send_with_retry(cmd, payload, msg_id, timeout, deadline, op_id)
                 if not future.done():

--- a/server/src/unity_mcp/server_filtering.py
+++ b/server/src/unity_mcp/server_filtering.py
@@ -263,6 +263,7 @@ async def discover_port_with_retry(
 # to the client outside of a request context (e.g. from a manual reconnect).
 _active_session = None
 _labeled_sessions: weakref.WeakSet = weakref.WeakSet()
+_background_tasks: set = set()  # strong refs to fire-and-forget tasks (S7502)
 
 
 def get_active_session():
@@ -324,4 +325,6 @@ def _schedule_client_label(session, get_slot) -> None:
             _labeled_sessions.discard(session)
             logger.debug("set_client_label failed for %r: %s", name, e)
 
-    asyncio.create_task(_send())
+    task = asyncio.create_task(_send())
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)

--- a/server/src/unity_mcp/tools/runtime.py
+++ b/server/src/unity_mcp/tools/runtime.py
@@ -219,7 +219,7 @@ async def _transition_play_state(expected: bool) -> None:
 
 def _is_playtest_pass(result: str) -> bool:
     """Require a non-empty, complete PLAYTEST ratio and no failure signals."""
-    first_line = (result or "").splitlines()[0] if result else ""
+    first_line = result.splitlines()[0] if result else ""
     match = re.match(r"PLAYTEST:\s*(\d+)\s*/\s*(\d+)\b", first_line)
     if not match:
         return False

--- a/server/tests/test_bridge_queue.py
+++ b/server/tests/test_bridge_queue.py
@@ -120,3 +120,22 @@ async def test_queue_consumer_stops_on_close():
     assert task is None or task.done(), (
         "close() should stop the queue consumer task"
     )
+
+
+async def test_queue_consumer_cancelled_error_propagates():
+    """Bug 3 regression: CancelledError in _queue_consumer must propagate, not be swallowed.
+
+    Pre-fix: `except asyncio.CancelledError: break` silently exited the loop
+    (task completed normally).  Post-fix: `raise` → task is properly cancelled.
+    """
+    bridge = _make_bridge()
+    # Start consumer directly — it blocks waiting on the empty queue.
+    consumer = asyncio.ensure_future(bridge._queue_consumer())
+    await asyncio.sleep(0)  # yield so consumer enters await get()
+
+    consumer.cancel()
+    await asyncio.sleep(0)  # let cancellation propagate
+
+    assert consumer.cancelled(), (
+        "Bug 3: _queue_consumer must re-raise CancelledError (not break)"
+    )

--- a/server/tests/test_runtime.py
+++ b/server/tests/test_runtime.py
@@ -818,3 +818,35 @@ async def test_run_playtest_suite_auto_play_cleanup_on_send_error(monkeypatch):
         pass
 
     assert stop_called, "DEF-1: Play Mode not stopped after auto_play + send error"
+
+
+# ── Bug 1 regression: _is_playtest_pass redundant-or fix (SonarCloud S1871) ───
+
+def test_is_playtest_pass_empty_string_returns_false():
+    """Bug 1: _is_playtest_pass('') must return False without raising IndexError."""
+    from unity_mcp.tools.runtime import _is_playtest_pass
+    assert _is_playtest_pass("") is False
+
+
+def test_is_playtest_pass_valid_full_pass():
+    """_is_playtest_pass returns True for complete passing ratio."""
+    from unity_mcp.tools.runtime import _is_playtest_pass
+    assert _is_playtest_pass("PLAYTEST: 3/3 (1.0s) OK") is True
+
+
+def test_is_playtest_pass_partial_fail():
+    """_is_playtest_pass returns False when not all assertions pass."""
+    from unity_mcp.tools.runtime import _is_playtest_pass
+    assert _is_playtest_pass("PLAYTEST: 1/3 (1.0s)\n[2] FAIL") is False
+
+
+def test_is_playtest_pass_console_err_token():
+    """_is_playtest_pass returns False when CONSOLE_ERR appears in result."""
+    from unity_mcp.tools.runtime import _is_playtest_pass
+    assert _is_playtest_pass("PLAYTEST: 2/2 (1.0s)\n[1] CONSOLE_ERR msg") is False
+
+
+def test_is_playtest_pass_zero_total():
+    """_is_playtest_pass returns False for 0/0 (no assertions)."""
+    from unity_mcp.tools.runtime import _is_playtest_pass
+    assert _is_playtest_pass("PLAYTEST: 0/0 (0.0s) OK") is False

--- a/server/tests/test_server_filtering.py
+++ b/server/tests/test_server_filtering.py
@@ -815,3 +815,12 @@ async def test_schedule_client_label_retries_after_send_failure():
     await asyncio.sleep(0)
 
     assert bridge.send.await_count == 2
+
+
+# ── Bug 2 regression: fire-and-forget task strong ref (SonarCloud S7502) ──────
+
+def test_background_tasks_is_module_level_set():
+    """Bug 2: _background_tasks must be a module-level set so GC cannot collect tasks."""
+    import unity_mcp.server_filtering as sf
+    assert hasattr(sf, "_background_tasks")
+    assert isinstance(sf._background_tasks, set)


### PR DESCRIPTION
## Summary

- Fix 3 Python bugs found by SonarCloud (S2583, S7502, S7497)
- Enable C# analysis via dotnet-sonarscanner + Unity .sln generation in CI

## Python Bug Fixes
- `runtime.py:222`: remove redundant `or ""` (condition always true)
- `server_filtering.py:327`: store asyncio task to prevent GC collection
- `bridge.py:328`: re-raise `CancelledError` instead of `break`

## CI Changes
- `ci-sonar.yml`: two-job workflow — python-coverage + sonar-unified (with Unity)

## Test plan
- [x] 7 new regression tests
- [x] 6275 Python tests pass
- [x] YAML syntax validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)