### PR TITLE
ci: validate Dependabot #88 action bumps with secrets (do not merge)

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.14' && matrix.os == 'ubuntu-latest'
         continue-on-error: true
-        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac  # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           files: server/coverage.xml
           flags: python
@@ -134,7 +134,7 @@ jobs:
       - name: Upload test analytics to Codecov
         if: matrix.python-version == '3.14' && matrix.os == 'ubuntu-latest' && !cancelled()
         continue-on-error: true
-        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac  # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           files: server/reports/server-junit.xml,server/reports/install-junit.xml,server/reports/scripts-junit.xml
           flags: python

--- a/.github/workflows/ci-sonar.yml
+++ b/.github/workflows/ci-sonar.yml
@@ -28,8 +28,8 @@ jobs:
     outputs:
       csharp: ${{ steps.filter.outputs.csharp }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -41,9 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.14'
 
@@ -61,7 +61,7 @@ jobs:
             sed -i 's|filename="src/|filename="server/src/|g' server/coverage.xml
           fi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: coverage-xml
           path: server/coverage.xml
@@ -73,11 +73,11 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.csharp == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Check InspectCode cache
         id: ic-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: sonarqube-csharp.json
           key: inspectcode-${{ hashFiles('unity-plugin/**/*.cs', 'scripts/inspectcode_to_sonar.py') }}
@@ -87,20 +87,20 @@ jobs:
         id: upm-path
         run: echo "path=$HOME/.cache/Unity/upm" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         if: steps.ic-cache.outputs.cache-hit != 'true'
         with:
           path: ${{ steps.upm-path.outputs.path }}
           key: upm-Linux-${{ hashFiles('unity-test-project/Packages/packages-lock.json') }}
           restore-keys: upm-Linux-
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         if: steps.ic-cache.outputs.cache-hit != 'true'
         with:
           path: ~/.dotnet/tools
           key: dotnet-tools-jb-${{ runner.os }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         if: steps.ic-cache.outputs.cache-hit != 'true'
         with:
           path: ~/.cache/jb-inspectcode
@@ -133,7 +133,7 @@ jobs:
           project-path: unity-test-project
           args: -batchmode -nographics -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -quit
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v6
         if: steps.ic-cache.outputs.cache-hit != 'true'
         with:
           dotnet-version: '8.0.x'
@@ -164,7 +164,7 @@ jobs:
           fi
           echo "Final: $(wc -c < sonarqube-csharp.json) bytes, $(python3 -c "import json; d=json.load(open('sonarqube-csharp.json')); print(len(d.get('issues',[])), 'issues,', len(d.get('rules',[])), 'rules')")"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: csharp-issues
           path: sonarqube-csharp.json
@@ -179,23 +179,23 @@ jobs:
       needs.python-coverage.result == 'success' &&
       (needs.csharp-inspect.result == 'success' || needs.csharp-inspect.result == 'skipped')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: coverage-xml
           path: server
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: csharp-issues
           path: .
         continue-on-error: true
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v3
+        uses: SonarSource/sonarcloud-github-action@v5
         with:
           args: >
             ${{ hashFiles('sonarqube-csharp.json') != '' && '-Dsonar.externalIssuesReportPaths=sonarqube-csharp.json' || '' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b  # v3
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v3
         with:
           languages: python
           config: |
@@ -45,6 +45,6 @@ jobs:
               - '**/test_*'
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b  # v3
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v3
         with:
           category: "/language:python"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -63,4 +63,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346  # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
               f.write('CHANGELOG_EOF\n')
           "
 
-      - uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228  # v3.0.2
+      - uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64  # v3.0.3
         with:
           tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
           body: ${{ steps.changelog.outputs.body }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -340,7 +340,7 @@ jobs:
 
       - name: Upload C# coverage to Codecov
         if: steps.cov-files.outputs.files != ''
-        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac  # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           files: ${{ steps.cov-files.outputs.files }}
           flags: csharp
@@ -350,7 +350,7 @@ jobs:
 
       - name: Upload test analytics to Codecov
         if: hashFiles('artifacts/editmode-results.xml') != ''
-        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac  # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           files: artifacts/editmode-results.xml
           flags: csharp


### PR DESCRIPTION
## What

Validation run for Dependabot #88 (13 GitHub Actions bumps across 6 workflows) merged onto current `master`, so the Unity/Sonar/Codecov jobs run with repository secrets — Dependabot-authored PRs cannot activate the Unity license, which is why #88 shows red Unity jobs.

## Why

`codecov/codecov-action` 5 → 7, `actions/upload-artifact` 4 → 7, `actions/cache` 4 → 6, `actions/setup-dotnet` 4 → 6, `SonarSource/sonarcloud-github-action` v3 → v5, `softprops/action-gh-release` 3.0.2 → 3.0.3 and friends touch artifact/coverage/release plumbing that only a secrets-enabled run can prove.

## Test evidence

CI on this PR is the evidence. Not meant to be merged: once green, #88 itself is squash-merged and this PR is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RE4nJPPnS1nJFX44gGCpgB
